### PR TITLE
New Catalogue Volksarmee, Wrong MG Profile in Red Thunder, Typos

### DIFF
--- a/Red Thunder - Soviets in World War III.cat
+++ b/Red Thunder - Soviets in World War III.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="aed7-aa45-90a5-ecbd" name="Red Thunder - Soviets in World War III" revision="2" battleScribeVersion="2.03" authorName="Nicolas Dohrendorf" authorContact="nicolas.dohrendorf@gmail.com" library="false" gameSystemId="9096-fd85-6ba1-72c5" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="aed7-aa45-90a5-ecbd" name="Red Thunder - Soviets in World War III" revision="3" battleScribeVersion="2.03" authorName="Nicolas Dohrendorf" authorContact="nicolas.dohrendorf@gmail.com" library="false" gameSystemId="9096-fd85-6ba1-72c5" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="2dd9-018c-3821-dd24" name="Red Thunder - Soviets in World War III" shortName="Red Thunder" publisher="ISBN 9780994147417" publicationDate="2017" publisherUrl="www.team-yankee.com"/>
   </publications>
@@ -2069,7 +2069,7 @@
         <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">6</characteristic>
         <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">4</characteristic>
         <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">6</characteristic>
-        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
         <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Dedicated AA, Radar</characteristic>
       </characteristics>
     </profile>
@@ -2133,7 +2133,7 @@
     </profile>
     <profile id="a8db-ccd7-4dce-0d74" name="AT-3 Sagger Missile" publicationId="2dd9-018c-3821-dd24" page="23" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
       <characteristics>
-        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm - 44&quot; / 110cm</characteristic>
         <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
         <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
         <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">19</characteristic>
@@ -2674,6 +2674,16 @@
         <characteristic name="Movement" typeId="0683-6f3b-3779-ddb2">UNLIMITED</characteristic>
       </characteristics>
     </profile>
+    <profile id="8bf4-ac5a-776b-28fb" name="7.62mm MG (BMP)" publicationId="2dd9-018c-3821-dd24" page="20" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">2</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93"/>
+      </characteristics>
+    </profile>
   </sharedProfiles>
   <sharedInfoGroups>
     <infoGroup id="e330-12a9-5851-6424" name="125mm 2A46 Gun" hidden="false">
@@ -2757,7 +2767,7 @@
         <infoLink id="3a3d-6d1a-f429-899c" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
         <infoLink id="b2ad-e0fe-3a66-a64d" name="BMP-1" hidden="false" targetId="df9d-db95-e288-f921" type="profile"/>
         <infoLink id="092c-d3c0-430c-8d67" name="AT-3 Sagger Missile" hidden="false" targetId="ccba-d530-d76f-a4e0" type="infoGroup"/>
-        <infoLink id="df07-9cf4-a939-e2e7" name="7.62mm MG" hidden="false" targetId="ff35-1171-70bc-51fa" type="profile"/>
+        <infoLink id="df07-9cf4-a939-e2e7" name="7.62mm MG (BMP)" hidden="false" targetId="8bf4-ac5a-776b-28fb" type="profile"/>
         <infoLink id="094e-e47d-441f-abad" name="73mm 2A28 Gun" hidden="false" targetId="db4a-4116-b0c0-19ec" type="infoGroup"/>
       </infoLinks>
     </infoGroup>
@@ -2773,7 +2783,7 @@
         <infoLink id="9164-3d67-0473-5406" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
         <infoLink id="4ae7-c1b2-df36-2113" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
         <infoLink id="c43d-d6a6-e0f3-b919" name="Spearhead" hidden="false" targetId="e9cf-a511-2a6a-6507" type="rule"/>
-        <infoLink id="c028-2152-0911-d52a" name="7.62mm MG" hidden="false" targetId="ff35-1171-70bc-51fa" type="profile"/>
+        <infoLink id="c028-2152-0911-d52a" name="7.62mm MG (BMP)" hidden="false" targetId="8bf4-ac5a-776b-28fb" type="profile"/>
         <infoLink id="dc45-86d1-43ed-decf" name="BMP-2" hidden="false" targetId="7c8d-c7a9-aaf8-2afa" type="profile"/>
         <infoLink id="4a4b-a633-a987-2f91" name="30mm 2A42 Gun" hidden="false" targetId="5c4f-d3aa-269e-afa1" type="infoGroup"/>
         <infoLink id="545a-7018-e012-2e2c" name="AT-5  Spandrel Missile" hidden="false" targetId="c623-3761-d8bd-9794" type="infoGroup"/>
@@ -2985,7 +2995,7 @@
         <infoLink id="74ec-c176-0a8a-4131" name="Observer" hidden="false" targetId="e41f-bf7a-3766-c44c" type="rule"/>
         <infoLink id="4a3a-7884-70f9-b7ca" name="Scout" hidden="false" targetId="9df5-f39b-4148-24ca" type="rule"/>
         <infoLink id="8770-ae69-23dc-8819" name="BMP-1 OP" hidden="false" targetId="93cd-e83f-9c07-d430" type="profile"/>
-        <infoLink id="977f-b5d6-ebc6-18bd" name="7.62mm MG" hidden="false" targetId="ff35-1171-70bc-51fa" type="profile"/>
+        <infoLink id="977f-b5d6-ebc6-18bd" name="7.62mm MG (BMP)" hidden="false" targetId="8bf4-ac5a-776b-28fb" type="profile"/>
       </infoLinks>
     </infoGroup>
     <infoGroup id="f156-c71e-8266-7693" name="2S3 Acacia" hidden="false">

--- a/Team Yankee WW3.gst
+++ b/Team Yankee WW3.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="9096-fd85-6ba1-72c5" name="Team Yankee WW3" revision="2" battleScribeVersion="2.03" authorName="Walter Vining" authorContact="toasterfree@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="9096-fd85-6ba1-72c5" name="Team Yankee WW3" revision="3" battleScribeVersion="2.03" authorName="Walter Vining" authorContact="toasterfree@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <readme>Still a work in progress. Will be adding other forces as I can acquire the books or cards to do so.</readme>
   <publications>
     <publication id="ce0d-b868-73d3-d028" name="American" shortName="American" publisher="American"/>
@@ -250,8 +250,8 @@ When Deploying their remaining Units, a player may trreat the area entirely with
     <rule id="63c4-326e-93d2-76aa" name="Passengers 1" hidden="false">
       <description>A Transport Team can carry 1 Infantry Teams as Passengers. </description>
     </rule>
-    <rule id="b814-659f-46f8-b83a" name="Assualt #" publicationId="cc6b-118f-f23b-6738" hidden="false">
-      <description>Teams with the Assualt # speical rule use this number for To Hit rolls in Assualts rather than the normal one hsown on the card.</description>
+    <rule id="b814-659f-46f8-b83a" name="Assault #" publicationId="cc6b-118f-f23b-6738" hidden="false">
+      <description>Teams with the Assualt # special rule use this number for To Hit rolls in Assaults rather than the normal one shown on the card.</description>
     </rule>
     <rule id="60ba-123c-4f2a-1604" name="AA MG" publicationId="cc6b-118f-f23b-6738" hidden="false">
       <description>AA MG Weapons can Shoot at Aircraft with a ROF of 1</description>

--- a/Volksarmee - East Germans in World War III.cat
+++ b/Volksarmee - East Germans in World War III.cat
@@ -1,0 +1,2278 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="c32a-4176-7f9a-d108" name="Volksarmee - East Germans in World War III" revision="2" battleScribeVersion="2.03" authorName="Nicolas Dohrendorf" authorContact="nicolas.dohrendorf@gmail.com" library="false" gameSystemId="9096-fd85-6ba1-72c5" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <publications>
+    <publication id="834e-dfb7-5188-8567" name="Volksarmee - East Germans in World War III" shortName="Volksarmee" publisher="ISBN 9780992251635" publicationDate="2016" publisherUrl="www.team-yankee.com"/>
+  </publications>
+  <categoryEntries>
+    <categoryEntry id="b1a3-ed62-1b98-0c0a" name="Artillery Unit" hidden="false"/>
+    <categoryEntry id="f44d-f316-97ff-1033" name="Panzer Bataillon" hidden="false"/>
+    <categoryEntry id="5b5b-63d8-d402-c266" name="Recon Zug" hidden="false"/>
+  </categoryEntries>
+  <forceEntries>
+    <forceEntry id="88b5-848b-d9a6-3150" name="9. Panzer Division" hidden="false">
+      <categoryLinks>
+        <categoryLink id="2f49-6aa3-ad42-5481" name="Combat Formation" hidden="false" targetId="49c4-0317-f106-84c7" primary="false"/>
+        <categoryLink id="d194-b23d-2741-ba8d" name="Support Unit" hidden="false" targetId="f947-2750-08c3-d4fc" primary="false"/>
+        <categoryLink id="ec0f-5143-050c-ee67" name="Artillery Unit" hidden="false" targetId="b1a3-ed62-1b98-0c0a" primary="false"/>
+        <categoryLink id="0729-e0b8-632f-d5ad" name="Formation Support" hidden="false" targetId="ccc5-e668-a26d-db83" primary="false"/>
+        <categoryLink id="0f4e-d274-8403-0839" name="Panzer Bataillon" hidden="false" targetId="f44d-f316-97ff-1033" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24f2-fc9e-0ea1-31e0" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="3d4a-41de-d1bc-b742" name="Recon Zug" hidden="false" targetId="5b5b-63d8-d402-c266" primary="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9326-8d0d-06c5-f440" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+  </forceEntries>
+  <entryLinks>
+    <entryLink id="5e36-01fe-cff6-909f" name="MI-24 Hind Battle Helicopter Squadron" hidden="false" collective="false" import="true" targetId="28fd-e5c2-9d01-38a1" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb60-4ed9-6ef3-bdd0" type="max"/>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e862-d8ad-1617-c91a" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="06b5-9c40-bcd0-5c5d" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="18e3-879f-ee0e-6591" name="SU-25 Frogfoot Aviation Company" hidden="false" collective="false" import="true" targetId="7953-9285-5384-00bd" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1001-583d-fbfd-cfd4" type="max"/>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e3-5152-aa3e-aaee" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="444e-e6a3-9048-70f9" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b8b9-2908-892f-22b7" name="Spandrel Panzerabwehr Zug" hidden="false" collective="false" import="true" targetId="6cf8-f356-14b7-cc25" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54a9-bbfe-f113-b98e" type="max"/>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8659-a114-6212-01a6" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="cc04-e95b-cb77-779a" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2a97-7f68-42dc-482a" name="T-55AM2 Panzer Bataillon" hidden="false" collective="false" import="true" targetId="1f52-bc34-7bcb-a595" type="selectionEntry">
+      <modifiers>
+        <modifier type="decrement" field="c8e9-ec91-460c-69cc" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1c72-cfe8-50da-4fc8" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8e9-ec91-460c-69cc" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b0a7-6f43-d9ff-e3be" name="New CategoryLink" hidden="false" targetId="49c4-0317-f106-84c7" primary="true"/>
+        <categoryLink id="80f5-59e9-cdb1-af31" name="Panzer Bataillon" hidden="false" targetId="f44d-f316-97ff-1033" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="a1e1-84a1-3a23-2841" name="T-72M Panzer Bataillon" hidden="false" collective="false" import="true" targetId="1c72-cfe8-50da-4fc8" type="selectionEntry">
+      <modifiers>
+        <modifier type="decrement" field="3a48-404d-400a-dc71" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f52-bc34-7bcb-a595" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a48-404d-400a-dc71" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="58ee-3e3e-456a-7874" name="New CategoryLink" hidden="false" targetId="49c4-0317-f106-84c7" primary="true"/>
+        <categoryLink id="00f4-2818-64f9-f642" name="Panzer Bataillon" hidden="false" targetId="f44d-f316-97ff-1033" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="274d-3a79-d46c-f6f0" name="2S1 Carnation Artillerie Batterie" hidden="false" collective="false" import="true" targetId="5ca1-31b2-4c10-e2d3" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da55-6076-edb0-cf8e" type="max"/>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="808e-06d0-5a2f-5bd2" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="9a1d-6ab1-9904-4ae4" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="53de-3dbb-8eae-c48b" name="BMP-1 Observation Post" hidden="false" collective="false" import="true" targetId="a864-08d8-5491-b682" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="b57e-a838-dd9c-030f" value="1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b1a3-ed62-1b98-0c0a" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b57e-a838-dd9c-030f" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ce95-fc9c-4de7-00ac" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="fe83-c6f1-937f-06fe" name="BM-21 Hail Raketenwerfer Batterie" hidden="false" collective="false" import="true" targetId="c10f-45e3-3889-81f3" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fd0-5de5-c1a4-664e" type="max"/>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5568-f6ac-bf78-544a" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="e811-1517-af57-0ebb" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="19a7-267f-d41c-da39" name="BMP-1 Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="e074-b596-a6de-dcd3" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5ae-43ce-be39-514a" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="9177-57f3-19f7-c823" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+        <categoryLink id="be11-11a8-f53a-0936" name="Recon Zug" hidden="false" targetId="5b5b-63d8-d402-c266" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5a94-4b88-431c-d7d8" name="BRDM Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="f0fb-3cfc-5923-fa04" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="bf55-1a46-8bd5-bdb6" value="0.0">
+          <comment>You can have at most either 1 BMP-1 Aufklärungs Zug or 1 BRDM Aufklärungs Zug</comment>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e074-b596-a6de-dcd3" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf55-1a46-8bd5-bdb6" type="max">
+          <comment></comment>
+        </constraint>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="d0a9-6f08-9b7c-a804" name="New CategoryLink" hidden="false" targetId="f947-2750-08c3-d4fc" primary="true"/>
+        <categoryLink id="8a24-21ab-a008-383d" name="Recon Zug" hidden="false" targetId="5b5b-63d8-d402-c266" primary="false"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="4d2c-0645-5622-635b" name="BMP Mot-Schützen Bataillon" hidden="false" collective="false" import="true" targetId="86d3-6db3-5789-b609" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bba-1fef-a9be-479f" type="max"/>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="296e-6450-cb9e-1ef5" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ee6d-50e3-5ff3-e20b" name="New CategoryLink" hidden="false" targetId="49c4-0317-f106-84c7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="ce8b-992e-cf6c-8a3a" name="BTR-60 Mot-Schützen Bataillon" hidden="false" collective="false" import="true" targetId="e8b8-a722-07b1-8ac1" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="cab4-4782-0e92-0a9c" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c71-8930-81f7-8917" type="max"/>
+        <constraint field="selections" scope="88b5-848b-d9a6-3150" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93b2-a53c-acf9-0135" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="02d9-9a7f-0f2f-1a43" name="New CategoryLink" hidden="false" targetId="49c4-0317-f106-84c7" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e891-6b77-63ee-1c86" name="T-55AM2 Panzer Bataillon HQ" publicationId="834e-dfb7-5188-8567" page="12" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="ab2e-17df-45c5-9cbf" name="1x T-55AM" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf61-93b3-2346-aeee" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b87-9d64-de40-7b1f" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f94a-e8c6-db55-d137" name="T-55AM2 HQ" hidden="false" targetId="2ff0-5a96-bf0a-344b" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="7bc4-70f6-71d4-79be" name="T-55AM2 Panzer Kompanie" publicationId="834e-dfb7-5188-8567" page="13" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="570b-6ab1-3f4d-2655" name="Fit up to three T-55AM2 Tanks with Mine-Clearing Devices" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c61-bd1f-5f04-1e91" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="60d5-00f3-500d-220f" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="9106-c9c2-d705-4d9c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a799-37f9-574c-30f2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f988-842c-fa40-6641" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9106-c9c2-d705-4d9c" name="3x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="a401-945c-74ae-981f" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8c01-1e83-fe24-a225" name="4x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="608c-e4ef-9a26-c336" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="4.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2af7-6bb5-5783-be84" name="5x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="9c35-9205-3049-499c" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="096a-3ae4-7920-d806" name="6x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="cae4-dd96-e1d0-9edd" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2b18-c131-b4ff-54e2" name="7x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="4399-7eae-ac24-ac3f" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ff30-8429-b4b9-d6e5" name="8x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="41a3-3ee2-e5d8-f5d7" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="12.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="20b4-c0bd-5594-f068" name="9x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="2bc1-e530-2237-9168" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="14.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1156-696b-b8e1-c700" name="10x T-55AM2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="f12e-2019-7779-bd62" name="T-55AM2" hidden="false" targetId="0615-7b78-d9be-9aa8" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="16.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="8d8f-f50d-90ff-afb9" name="T-72M Panzer Bataillon HQ" publicationId="834e-dfb7-5188-8567" page="14" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="9c13-0182-a5b9-117c" name="1x T-72M" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9788-8ac9-5cb9-1b17" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea4-db8b-0cef-af42" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="bb68-f258-dcbb-21e9" name="T-72M HQ" hidden="false" targetId="676b-0807-3ec4-e6e8" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="3.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="0e8d-642c-67c6-0564" name="T-72M Panzer Kompanie" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="db59-151c-557f-934c" name="Fit up to three T-72M Tanks with Mine-Clearing Devices" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d37e-c549-37e3-b86e" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cb35-88db-6d0c-d0a8" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="f387-9cea-16bc-2b25">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc34-fb08-8ba5-0a7f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f417-daf7-e154-7656" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f387-9cea-16bc-2b25" name="3x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="7da6-fe53-2a33-0d21" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dc8a-907e-f81f-e822" name="4x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="7f8f-0416-6178-cf00" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="11.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5a54-1ca4-3d26-9e92" name="5x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="6abc-13c9-89cb-5c8a" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a960-5ff7-5cb2-28a2" name="6x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="416b-5979-3e9c-b37b" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="19.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="06d9-3718-0acd-e0dd" name="7x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="5a3a-3c13-8103-ae8f" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="23.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1135-8b98-22cf-e059" name="8x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="7783-0684-2fa9-62ca" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="27.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="070d-7f6c-5c2d-0bc7" name="9x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="5bdc-d2e6-6753-f77e" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="31.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0b4f-76fc-d7c0-7cb2" name="10x T-72M" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="1a79-88e9-ca71-ba93" name="T-72M" hidden="false" targetId="996e-53a5-bace-e802" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="9f35-741f-de4e-5ea0" name="BMP Mot-Schützen Bataillon HQ" publicationId="834e-dfb7-5188-8567" page="16" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="bd05-9f98-9bed-633e" name="1x MPi KM Team, 1x BMP-1" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8196-2851-c982-f2ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52fd-c83d-5f3a-d668" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a4ee-857a-8804-7f9b" name="BMP-1 Transport" hidden="false" targetId="a47c-ccb6-9cd3-1a95" type="infoGroup"/>
+            <infoLink id="6fc1-86df-a142-d6ef" name="MPi KM team" hidden="false" targetId="2261-85c9-7379-793e" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="b0fe-7954-8a55-d852" name="BMP-1 Mot-Schützen Kompanie" publicationId="834e-dfb7-5188-8567" page="17" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="d02b-fe7d-d699-e069" name="Add 1x AGS-17 Grenade Launcher Team &amp; 1x BMP-1" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="791a-2506-7cea-5a61" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0085-f8cc-b78d-18b7" name="AGS-17 Grenade Launcher Team" hidden="false" targetId="8a5a-ae19-8ac9-f046" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a9a0-f3a0-bac4-657e" name="Add 1x SA-14 Gremlin AA Missile Team &amp; 1x BMP-1" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9794-93aa-02ec-ec66" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6586-4e2e-4411-613c" name="SA-14 Gremlin AA Missile Team" hidden="false" targetId="7f06-4e86-450a-eec5" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8bcf-46e8-4435-c08a" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="36c8-e137-fb92-a587">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="588e-a093-36b7-10da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7083-f069-bc2c-92f4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="36c8-e137-fb92-a587" name="4x MPi KM Team with RPG-18 Anti-Tank, 3x RPG-7 Anti-Tank Team, 4x BMP-1" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="d3d4-904d-f6c6-9e20" name="BMP-1 Transport" hidden="false" targetId="a47c-ccb6-9cd3-1a95" type="infoGroup"/>
+                <infoLink id="8417-3b49-a554-dfa0" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="a17c-32b8-1630-4516" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e396-f12f-96c8-221d" name="7x MPi KM Team with RPG-18 Anti-Tank, 6x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 9x BMP-1" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="e846-680c-c41b-c388" name="BMP-1 Transport" hidden="false" targetId="a47c-ccb6-9cd3-1a95" type="infoGroup"/>
+                <infoLink id="7bff-8333-a25e-eafa" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="6edc-3c57-840a-b8a5" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="ff47-40d5-c1aa-3ddf" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="14.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0e17-9b40-5350-13df" name="10x MPi KM Team with RPG-18 Anti-Tank, 9x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 12x BMP-1" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="c6e7-3753-02b7-b9d9" name="BMP-1 Transport" hidden="false" targetId="a47c-ccb6-9cd3-1a95" type="infoGroup"/>
+                <infoLink id="1c6f-ad01-9cc5-bf7b" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="300c-012b-a9ed-5227" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="4f69-f949-61c2-3f12" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="19.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="ca39-e034-d3c0-52cf" name="BMP-2 Mot-Schützen Kompanie" publicationId="834e-dfb7-5188-8567" page="18" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="9d58-7999-daf9-3100" name="Add 1x AGS-17 Grenade Launcher Team &amp; 1x BMP-2" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="164e-6109-3ee5-628c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1812-8c26-cf46-c1bb" name="AGS-17 Grenade Launcher" hidden="false" targetId="f202-af51-5bdd-b993" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f91b-3bdf-c96f-de06" name="Add 1x SA-14 Gremlin AA Missile Team &amp; 1x BMP-2" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e77a-2fb2-00ec-d1a6" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="a29f-7593-ea96-8153" name="SA-14 Gremlin AA Missile Team" hidden="false" targetId="7f06-4e86-450a-eec5" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2734-46b4-2f41-20d8" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="05c5-316c-ddd2-3239">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bd3-e4b2-8214-2e88" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc00-42a9-4856-9c65" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="05c5-316c-ddd2-3239" name="4x MPi KM Team with RPG-18 Anti-Tank, 3x RPG-7 Anti-Tank Team, 4x BMP-2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="c383-d7c9-0bba-4043" name="BMP-2 Transport" hidden="false" targetId="1230-22e4-dde4-c526" type="infoGroup"/>
+                <infoLink id="9f1e-8de9-b086-6e8c" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="06f9-f2cc-0196-5783" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="8.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7a03-7a05-0081-782d" name="7x MPi KM Team with RPG-18 Anti-Tank, 6x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 9x BMP-2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="1278-d311-14b4-c228" name="BMP-2 Transport" hidden="false" targetId="1230-22e4-dde4-c526" type="infoGroup"/>
+                <infoLink id="838e-11d6-9ab1-6db7" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="a231-8c51-949c-ea92" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="0d3a-1d59-1e9f-ff36" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="18.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d405-5343-7498-2e63" name="10x MPi KM Team with RPG-18 Anti-Tank, 9x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 12x BMP-2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="9b7b-f3c3-00b7-63b4" name="BMP-2 Transport" hidden="false" targetId="1230-22e4-dde4-c526" type="infoGroup"/>
+                <infoLink id="9764-e09b-531d-2088" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="2917-82ff-fcee-fcb5" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="5aaf-7217-fc72-408c" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="24.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="e074-b596-a6de-dcd3" name="BMP-1 Aufklärungs Zug" publicationId="834e-dfb7-5188-8567" page="19" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6732-0bac-9775-e7c8" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="15d7-3fa8-0ed1-0472">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76c9-6f61-2f97-3110" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb84-03bc-15fc-0926" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="15d7-3fa8-0ed1-0472" name="2x BMP-1 Scout" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="9635-86d9-bb3e-4e25" name="BMP-1 Scout" hidden="false" targetId="1201-c37d-e42f-fe07" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="31a8-39de-257d-2aed" name="3x BMP-1 Scout" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="3dc2-eb59-fdae-bd96" name="BMP-1 Scout" hidden="false" targetId="1201-c37d-e42f-fe07" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d759-da98-eb90-dabb" name="4x BMP-1 Scout" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="cfe8-673f-cffb-b447" name="BMP-1 Scout" hidden="false" targetId="1201-c37d-e42f-fe07" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="4.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="f0fb-3cfc-5923-fa04" name="BRDM Aufklärungs Zug" publicationId="834e-dfb7-5188-8567" page="19" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="46f3-ead6-2c19-0210" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="83aa-a200-5e06-ac19">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77c2-00a1-0d3c-7dd7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4242-244e-b5bd-f215" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="83aa-a200-5e06-ac19" name="2x BRDM-2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="612e-2335-ed55-a052" name="BRDM-2" hidden="false" targetId="6aa0-ad60-8739-21a4" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="72bd-cfe9-51b2-5248" name="4x BRDM-2" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="6444-7024-28d8-3c09" name="BRDM-2" hidden="false" targetId="6aa0-ad60-8739-21a4" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="dca8-a64a-e98a-9950" name="BTR-60 Mot-Schützen Bataillon HQ" publicationId="834e-dfb7-5188-8567" page="20" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="e3de-4f0a-9932-8c33" name="1x MPi KM Team, 1x BTR-60" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7433-00bf-1c6d-e457" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f1d-01a8-62a1-ae01" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="be84-5fe0-5447-f78b" name="BTR-60 Transport" hidden="false" targetId="484d-16eb-e663-2d97" type="infoGroup"/>
+            <infoLink id="8f7a-d31f-0787-11be" name="MPi KM team" hidden="false" targetId="2261-85c9-7379-793e" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry id="4be4-3096-9811-2692" name="BTR-60 Mot-Schützen Kompanie" publicationId="834e-dfb7-5188-8567" page="21" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="f984-d4c9-1aad-fa07" name="Add 1x AGS-17 Grenade Launcher Team &amp; 1x BTR-60" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d09a-bb9f-5c6d-da67" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5b8d-e87f-1185-8188" name="AGS-17 Grenade Launcher Team" hidden="false" targetId="8a5a-ae19-8ac9-f046" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8ae8-778f-d6c6-67cf" name="Add 1x SA-14 Gremlin AA Missile Team &amp; 1x BTR-60" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="775b-115e-9606-f247" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="aca7-6b21-c9e0-27f7" name="SA-14 Gremlin AA Missile Team" hidden="false" targetId="7f06-4e86-450a-eec5" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ba1b-7d50-c268-3c38" name="Add 1x AT-4 Spigot Missile Team &amp; 1x BTR-60" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8180-9b30-e175-a907" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="806d-275b-4b68-58a7" name="AT-4 Spigot Missile Team" hidden="false" targetId="0547-667e-3bf4-998d" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d31c-b78f-080f-6389" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="66ea-b2fb-dd5f-d0e2">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05f5-c29a-fa1e-2633" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e80e-6686-7112-be4b" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="66ea-b2fb-dd5f-d0e2" name="4x MPi KM Team with RPG-18 Anti-Tank, 3x RPG-7 Anti-Tank Team, 4x BTR-60" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="bb8e-5b1c-7010-d8af" name="BTR-60 Transport" hidden="false" targetId="484d-16eb-e663-2d97" type="infoGroup"/>
+                <infoLink id="5242-2ea3-ffc3-4f96" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="e304-a7a8-6b77-d998" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ce1b-1b86-4107-69e8" name="7x MPi KM Team with RPG-18 Anti-Tank, 6x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 9x BTR-60" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="375c-4d40-7d17-e400" name="BTR-60 Transport" hidden="false" targetId="484d-16eb-e663-2d97" type="infoGroup"/>
+                <infoLink id="e90c-eb3d-1960-3494" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="9a14-9d9e-0bcb-b7b6" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="3b4e-6d83-4805-0cc7" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b307-754e-2d99-2ba0" name="10x MPi KM Team with RPG-18 Anti-Tank, 9x RPG-7 Anti-Tank Team, 2x PKM LMG Team, 12x BTR-60" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="44b1-75f3-a8c2-c3bd" name="BTR-60 Transport" hidden="false" targetId="484d-16eb-e663-2d97" type="infoGroup"/>
+                <infoLink id="7b80-6222-bc50-23a9" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="0992-7622-7154-3f09" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                <infoLink id="c040-961a-7df3-eaf4" name="PKM LMG Team" hidden="false" targetId="7155-8f80-7d87-3e6e" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="3d1a-18be-979b-fef2" name="ZSU-23-4 Shilka Zug" publicationId="834e-dfb7-5188-8567" page="22" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cb8a-e4b6-bb8d-f8b4" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="f457-5cec-7185-dd8d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc62-9f70-befd-b7bb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e26-ad7d-ddce-2b9f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f457-5cec-7185-dd8d" name="2x ZSU-23-4" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="f1a3-a1f4-88a3-33d2" name="ZSU-23-4 Shilka" hidden="false" targetId="8faf-afd1-3825-b756" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e43c-ccae-40e0-7366" name="4x ZSU-23-4" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="eee9-5307-fdc4-ed61" name="ZSU-23-4 Shilka" hidden="false" targetId="8faf-afd1-3825-b756" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="4.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="23c0-f7be-96be-894f" name="SA-13 Gopher Zug" publicationId="834e-dfb7-5188-8567" page="23" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="17e1-6d9d-f143-e6e7" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="959f-8a09-083c-d20b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff37-9942-fcdf-5f61" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dba-4bc7-32c1-a32c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="959f-8a09-083c-d20b" name="2x SA-13 Gopher" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="494f-7f2c-de8e-2426" name="SA-13 Gopher" hidden="false" targetId="5dbd-dd48-6390-3b32" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6969-2993-01d0-586d" name="4x SA-13 Gopher" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="ac3f-c038-0ff3-9245" name="SA-13 Gopher" hidden="false" targetId="5dbd-dd48-6390-3b32" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="4.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="3a3e-173c-6edd-73bc" name="SA-9 Gaskin Zug" publicationId="834e-dfb7-5188-8567" page="23" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4aa0-cde3-4905-8d29" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="6e84-05b7-12a0-e484">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb43-7288-4996-8cfb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de5b-b228-27ad-7517" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="6e84-05b7-12a0-e484" name="2x SA-9 Gaskin" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="1e90-8f72-8ad5-c6e8" name="SA-9 Gaskin" hidden="false" targetId="b7d8-ed39-ff7c-fc0f" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cb98-3212-e2d2-6524" name="4x SA-9 Gaskin" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="a69f-93a0-fdd4-7637" name="SA-9 Gaskin" hidden="false" targetId="b7d8-ed39-ff7c-fc0f" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="5ca1-31b2-4c10-e2d3" name="2S1 Carnation Artillerie Batterie" publicationId="834e-dfb7-5188-8567" page="24" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="8a34-46a5-2749-8b3b" name="Artillery Unit" hidden="false" targetId="b1a3-ed62-1b98-0c0a" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6090-a910-9e2e-3248" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="3006-2ec8-93fc-8608">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23d3-bba1-64de-14a9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a33-2a44-fa86-3ea1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3006-2ec8-93fc-8608" name="3x 2S1 Carnation" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="e5c2-8fc3-bbb7-41cd" name="2S1 Carnation" hidden="false" targetId="b439-7b1b-1cb8-4909" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a2d7-3170-eebe-c407" name="6x 2S1 Carnation" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="50cb-2ece-60c9-e275" name="2S1 Carnation" hidden="false" targetId="b439-7b1b-1cb8-4909" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="12.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="c10f-45e3-3889-81f3" name="BM-21 Hail Raketenwerfer Batterie" publicationId="834e-dfb7-5188-8567" page="24" hidden="false" collective="false" import="true" type="unit">
+      <categoryLinks>
+        <categoryLink id="ef58-908b-b6e7-5bbd" name="Artillery Unit" hidden="false" targetId="b1a3-ed62-1b98-0c0a" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3634-b5ee-15a2-5214" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="09c2-9188-f3ff-3044">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f30c-894d-5bab-5a16" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="997c-479e-cd5c-aa7f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="09c2-9188-f3ff-3044" name="3x BM-21 Hail" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="3148-3913-1027-418f" name="BM-21" hidden="false" targetId="623a-16c8-281a-144a" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="384b-5694-daaa-2a87" name="6x BM-21 Hail" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="691d-0d60-4e79-8e98" name="BM-21" hidden="false" targetId="623a-16c8-281a-144a" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="a864-08d8-5491-b682" name="BMP-1 Observation Post" publicationId="834e-dfb7-5188-8567" page="25" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntries>
+        <selectionEntry id="7a35-2664-54e6-82b5" name="1x BMP-1 OP" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="482a-461d-4444-8a49" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d421-ec07-3515-d867" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="0065-13d2-8a1d-637e" name="BMP-1 Observation Post" hidden="false" targetId="5abf-974f-8cd3-e144" type="infoGroup"/>
+          </infoLinks>
+          <costs>
+            <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6cf8-f356-14b7-cc25" name="Spandrel Panzerabwehr Zug" publicationId="834e-dfb7-5188-8567" page="25" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0299-abe0-0c02-5832" name="Unit-Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="0571-e7c7-42b9-8756">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cd0-2915-55bd-0684" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4d6-f90d-23ea-3ed4" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0571-e7c7-42b9-8756" name="2x Spandrel" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="73eb-5494-5d61-fed6" name="Spandrel" hidden="false" targetId="c354-3a5a-5c68-4116" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a8a6-8843-8fb7-8b13" name="3x Spandrel" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="6c6c-85d6-a95b-eeb0" name="Spandrel" hidden="false" targetId="c354-3a5a-5c68-4116" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="2.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="28fd-e5c2-9d01-38a1" name="MI-24 Hind Battle Helicopter Squadron" publicationId="834e-dfb7-5188-8567" page="26" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dd3e-9866-0305-9cf1" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="3a4d-fcf4-5ff0-7f02">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d964-fb26-c56f-c628" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7925-12c6-7302-7780" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3a4d-fcf4-5ff0-7f02" name="2x MI-24 Hind" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="9eb8-3fc9-1b40-13c0" name="MI-24 Hind" hidden="false" targetId="dfa7-4dbb-e22d-cc9f" type="infoGroup"/>
+              </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="2b15-c8b7-96fb-ab3e" name="MI-24 Assault Landing Company" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e798-3afd-782f-d762" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="acd9-865e-5480-5ab7" name="2x MPi KM Team with RPG-18 Anti-Tank, 2x RPG-7 Anti-Tank Team" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c31-3e10-88a1-0c2f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68c4-b897-39e9-4fcb" type="min"/>
+                      </constraints>
+                      <infoLinks>
+                        <infoLink id="d949-501c-a56e-e0cc" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                        <infoLink id="b2a6-235c-d864-179c" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntry>
+              </selectionEntries>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="6.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b5af-52c5-4ccb-653a" name="4x MI-24 Hind" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="5d3d-620c-1c07-b823" name="MI-24 Hind" hidden="false" targetId="dfa7-4dbb-e22d-cc9f" type="infoGroup"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="21c5-e1ac-d472-01e2" name="MI-24 Hind Assault Landing Company" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84ca-6dd3-4358-39d8" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="8f2f-06d0-7474-0d59" name="4x MPi KM Team with RPG-18 Anti-Tank, 4x RPG-7 Anti-Tank Team" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="03f3-f7a4-eb3d-e35e" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                        <infoLink id="6d6f-2280-eefc-be0d" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="Points" typeId="7216-9333-2b5d-9b72" value="3.0"/>
+                      </costs>
+                    </selectionEntry>
+                    <selectionEntry id="eef9-8073-8966-ffc6" name="2x MPi KM Team with RPG-18 Anti-Tank, 2x RPG-7 Anti-Tank Team" hidden="false" collective="false" import="true" type="upgrade">
+                      <infoLinks>
+                        <infoLink id="6241-c5a5-f4fa-3464" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                        <infoLink id="89bb-0e7d-ed09-4090" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+                      </infoLinks>
+                      <costs>
+                        <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="12.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="7953-9285-5384-00bd" name="SU-25 Frogfoot Aviation Company" publicationId="834e-dfb7-5188-8567" page="27" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7fea-0988-1635-48b2" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="bf0d-7cd6-1b90-9c2c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d99-c491-bf91-0f06" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99fc-00f0-bb95-89bf" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bf0d-7cd6-1b90-9c2c" name="2x SU-25 Frogfoot" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="b6a7-1fb2-dd80-1c71" name="SU-25 Frogfoot" hidden="false" targetId="e870-cb25-9e2e-55c5" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="7.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8b7d-c373-9c34-4dbb" name="4x SU-25 Frogfoot" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="87e7-9b97-3a87-0c63" name="SU-25 Frogfoot" hidden="false" targetId="e870-cb25-9e2e-55c5" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="14.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ea4c-85e5-1212-3c6f" name="6x SU-25 Frogfoot" hidden="false" collective="false" import="true" type="unit">
+              <infoLinks>
+                <infoLink id="8602-e3c7-f1f4-6bde" name="SU-25 Frogfoot" hidden="false" targetId="e870-cb25-9e2e-55c5" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="21.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="4d3b-2e73-7315-fed8" name="MI-24 Hind Assault Landing Company" publicationId="834e-dfb7-5188-8567" page="27" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c697-8bfa-b095-7ed5" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="5dbc-37c5-2f2a-faa1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6420-43cb-9ba6-0523" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="934d-16f1-ed6c-1701" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="034c-7f0a-1ec5-6c95" name="4x MPi KM Team with RPG-18 Anti-Tank, 4x RPG-7 Anti-Tank Team" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="f18a-7f81-f841-edc1" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="898f-9a8e-dbb3-ff6a" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5dbc-37c5-2f2a-faa1" name="2x MPi KM Team with RPG-18 Anti-Tank, 2x RPG-7 Anti-Tank Team" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="5824-385e-96e4-2c27" name="MPi KM team with RPG-18 Anti-Tank" hidden="false" targetId="2107-ea22-4683-d2d3" type="infoGroup"/>
+                <infoLink id="f618-f64b-6b8c-ffa7" name="RPG-7 Anti-Tank Team" hidden="false" targetId="2a6a-1725-a551-e1f3" type="infoGroup"/>
+              </infoLinks>
+              <costs>
+                <cost name="Points" typeId="7216-9333-2b5d-9b72" value="1.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntry>
+    <selectionEntry id="1f52-bc34-7bcb-a595" name="T-55AM2 Panzer Bataillon" publicationId="834e-dfb7-5188-8567" page="12" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6631-3e1e-2ccb-31d1" name="Optional T-72M Kompanie" hidden="false" collective="false" import="true" defaultSelectionEntryId="da64-4967-6a78-84ee">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fd-364d-68c4-4667" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b25-90fd-e60c-2894" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="24e4-766d-5f98-bafc" name="T-72M Panzer Kompanie" hidden="false" collective="false" import="true" targetId="0e8d-642c-67c6-0564" type="selectionEntry"/>
+            <entryLink id="da64-4967-6a78-84ee" name="T-55AM2 Panzer Kompanie" hidden="false" collective="false" import="true" targetId="7bc4-70f6-71d4-79be" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4af2-1cbc-086b-a2a7" name="Infantry Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a869-6de7-7a50-dcd2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2f44-3060-a38c-f7f3" name="BTR-60 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="4be4-3096-9811-2692" type="selectionEntry"/>
+            <entryLink id="46e2-2f0e-d693-987f" name="BMP-1 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="b0fe-7954-8a55-d852" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="595d-174d-7bc4-11d1" name="Recon Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63e9-4995-270a-f855" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0174-be2f-b473-c42a" name="BMP-1 Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="e074-b596-a6de-dcd3" type="selectionEntry"/>
+            <entryLink id="7179-af1b-6cbd-c16b" name="BRDM Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="f0fb-3cfc-5923-fa04" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3bc9-503e-edc2-1533" name="AA Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a00-1cc7-2df2-4667" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5e0b-2745-d4b4-9167" name="SA-13 Gopher Zug" hidden="false" collective="false" import="true" targetId="23c0-f7be-96be-894f" type="selectionEntry"/>
+            <entryLink id="eef3-caae-94b9-4ad2" name="SA-9 Gaskin Zug" hidden="false" collective="false" import="true" targetId="3a3e-173c-6edd-73bc" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7b6a-046b-7f0e-34a0" name="T-55AM2 Panzer Bataillon HQ" hidden="false" collective="false" import="true" targetId="e891-6b77-63ee-1c86" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="791d-75cb-d947-9ff5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac2b-259a-2d81-9e23" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5a5d-1279-0854-e9ec" name="T-55AM2 Panzer Kompanie" hidden="false" collective="false" import="true" targetId="7bc4-70f6-71d4-79be" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3775-c554-df1f-a2ee" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f2d6-c601-ef31-e333" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6744-5a2c-d610-e62b" name="ZSU-23-4 Shilka Zug" hidden="false" collective="false" import="true" targetId="3d1a-18be-979b-fef2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d21-7980-8d1b-45f5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="623f-b1b5-ee9a-cf42" name="2S1 Carnation Artillerie Batterie" hidden="false" collective="false" import="true" targetId="5ca1-31b2-4c10-e2d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ccf-f358-adfc-2e42" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="1c72-cfe8-50da-4fc8" name="T-72M Panzer Bataillon" publicationId="834e-dfb7-5188-8567" page="14" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6ef1-0e5d-59e5-fa54" name="Optional T-55AM2 Kompanie" hidden="false" collective="false" import="true" defaultSelectionEntryId="a26c-f9ea-d122-488a">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40f1-b13c-7909-9260" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2c5-5c3f-10b8-1fe0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a26c-f9ea-d122-488a" name="T-72M Panzer Kompanie" hidden="false" collective="false" import="true" targetId="0e8d-642c-67c6-0564" type="selectionEntry"/>
+            <entryLink id="27de-b85b-03bb-c6aa" name="T-55AM2 Panzer Kompanie" hidden="false" collective="false" import="true" targetId="7bc4-70f6-71d4-79be" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0f0a-f3c0-29e8-4a92" name="Recon Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad96-5ea0-00f2-1544" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c1c1-a7d5-0e35-5618" name="BMP-1 Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="e074-b596-a6de-dcd3" type="selectionEntry"/>
+            <entryLink id="3dd1-5ccf-3c5e-7788" name="BRDM Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="f0fb-3cfc-5923-fa04" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d73f-fd48-6e9c-b8b9" name="AA Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d25-ad02-bab4-e2c0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d883-99d8-76af-05e9" name="SA-13 Gopher Zug" hidden="false" collective="false" import="true" targetId="23c0-f7be-96be-894f" type="selectionEntry"/>
+            <entryLink id="7528-2680-8d2d-8221" name="SA-9 Gaskin Zug" hidden="false" collective="false" import="true" targetId="3a3e-173c-6edd-73bc" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e007-0410-4458-bf22" name="T-72M Panzer Bataillon HQ" hidden="false" collective="false" import="true" targetId="8d8f-f50d-90ff-afb9" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b80-40a9-f9d7-8d65" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="408e-4b63-2519-4e19" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c829-f9fa-18f3-56b0" name="T-72M Panzer Kompanie" hidden="false" collective="false" import="true" targetId="0e8d-642c-67c6-0564" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3564-9992-9eb5-e63b" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f99-ea7f-d25e-8a5f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="716e-34df-3011-8c19" name="BMP-1 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="b0fe-7954-8a55-d852" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d47-a812-024d-46a8" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f47b-3578-7770-ae02" name="ZSU-23-4 Shilka Zug" hidden="false" collective="false" import="true" targetId="3d1a-18be-979b-fef2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="955f-6e8b-af45-5436" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="46af-0e42-e4b7-229b" name="2S1 Carnation Artillerie Batterie" hidden="false" collective="false" import="true" targetId="5ca1-31b2-4c10-e2d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f403-ba7b-621d-28fa" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="86d3-6db3-5789-b609" name="BMP Mot-Schützen Bataillon" publicationId="834e-dfb7-5188-8567" page="16" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1d1a-0dea-cb86-2506" name="Optional BMP-2 Kompanie" hidden="false" collective="false" import="true" defaultSelectionEntryId="5140-c811-da63-1198">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c79e-a44e-ece8-2c9c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a6e-7210-5ad0-d8c5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5140-c811-da63-1198" name="BMP-1 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="b0fe-7954-8a55-d852" type="selectionEntry"/>
+            <entryLink id="d5e6-d55d-b571-07cf" name="BMP-2 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="ca39-e034-d3c0-52cf" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2d46-b2e5-f0c3-b7f3" name="Tank Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238c-9091-fa60-6892" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="3db5-05a8-b0d8-4def" name="T-72M Panzer Kompanie" hidden="false" collective="false" import="true" targetId="0e8d-642c-67c6-0564" type="selectionEntry"/>
+            <entryLink id="4c27-1caf-0fa2-f361" name="T-55AM2 Panzer Kompanie" hidden="false" collective="false" import="true" targetId="7bc4-70f6-71d4-79be" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="14b3-1b22-1cdb-1f31" name="Recon Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbce-3664-453a-01a5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a5dc-84d5-1c8d-19fd" name="BMP-1 Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="e074-b596-a6de-dcd3" type="selectionEntry"/>
+            <entryLink id="6a31-fa26-005e-41d4" name="BRDM Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="f0fb-3cfc-5923-fa04" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="42b7-35dc-f72a-51d0" name="AA Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3927-685d-4edb-d949" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e1ef-f700-f40f-9f17" name="SA-13 Gopher Zug" hidden="false" collective="false" import="true" targetId="23c0-f7be-96be-894f" type="selectionEntry"/>
+            <entryLink id="8b8b-b128-72ec-51c0" name="SA-9 Gaskin Zug" hidden="false" collective="false" import="true" targetId="3a3e-173c-6edd-73bc" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9d77-377b-1eb7-be1e" name="BMP-1 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="b0fe-7954-8a55-d852" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="adf4-5aac-fc1a-4ea9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2197-7a65-0703-e919" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ac49-1732-810d-49ea" name="ZSU-23-4 Shilka Zug" hidden="false" collective="false" import="true" targetId="3d1a-18be-979b-fef2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e13-08cc-0ba9-e3a1" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="50eb-42c2-e01c-2ca0" name="2S1 Carnation Artillerie Batterie" hidden="false" collective="false" import="true" targetId="5ca1-31b2-4c10-e2d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ebd-c16b-e72c-cd36" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8f37-442e-8f93-a0ca" name="Spandrel Panzerabwehr Zug" hidden="false" collective="false" import="true" targetId="6cf8-f356-14b7-cc25" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2db7-74d3-da31-4924" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b74b-42a1-a4a0-a5f5" name="BMP Mot-Schützen Bataillon HQ" hidden="false" collective="false" import="true" targetId="9f35-741f-de4e-5ea0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d07b-c19c-6572-e7c2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b91-c26b-dace-7bdb" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="e8b8-a722-07b1-8ac1" name="BTR-60 Mot-Schützen Bataillon" publicationId="834e-dfb7-5188-8567" page="20" hidden="false" collective="false" import="true" type="unit">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="47a0-36a4-4072-d580" name="AA Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c8-01a0-3df2-b4ae" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f8ee-27ae-be27-548d" name="SA-13 Gopher Zug" hidden="false" collective="false" import="true" targetId="23c0-f7be-96be-894f" type="selectionEntry"/>
+            <entryLink id="afcc-3a32-a559-6606" name="SA-9 Gaskin Zug" hidden="false" collective="false" import="true" targetId="3a3e-173c-6edd-73bc" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9e65-19e7-752b-4218" name="Recon Support" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8736-5c2b-a5fa-7c78" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5518-61bc-ad90-8fbc" name="BMP-1 Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="e074-b596-a6de-dcd3" type="selectionEntry"/>
+            <entryLink id="d808-bc68-290c-0bc2" name="BRDM Aufklärungs Zug" hidden="false" collective="false" import="true" targetId="f0fb-3cfc-5923-fa04" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7281-0bc6-5eaf-4e7f" name="BTR-60 Mot-Schützen Bataillon HQ" hidden="false" collective="false" import="true" targetId="dca8-a64a-e98a-9950" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2657-ba63-e905-c779" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d766-9583-471b-5da7" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="44be-223b-b991-9431" name="BTR-60 Mot-Schützen Kompanie" hidden="false" collective="false" import="true" targetId="4be4-3096-9811-2692" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb0c-ea13-f5a7-8c93" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eacf-36a8-7600-6d03" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b54d-924e-2dee-b06a" name="T-55AM2 Panzer Kompanie" hidden="false" collective="false" import="true" targetId="7bc4-70f6-71d4-79be" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a624-3375-d837-dcd9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="6207-acd2-e140-2b6a" name="Spandrel Panzerabwehr Zug" hidden="false" collective="false" import="true" targetId="6cf8-f356-14b7-cc25" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea49-dbf5-dc36-c786" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="e5f4-468a-e27f-1917" name="ZSU-23-4 Shilka Zug" hidden="false" collective="false" import="true" targetId="3d1a-18be-979b-fef2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7537-94ea-b790-d812" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c875-127c-109a-9e0e" name="2S1 Carnation Artillerie Batterie" hidden="false" collective="false" import="true" targetId="5ca1-31b2-4c10-e2d3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a27-8a93-a27e-1e70" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="e32c-57a4-c7ac-d368" name="Radar (ZSU-23-4)" hidden="false"/>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="c68b-38e7-ce4a-d572" name="T-55AM2 (HQ)" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">14&quot; / 35cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">20&quot; / 50cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">24&quot; / 60cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">14</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">9</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">2</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">3+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">2+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">3+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8c7f-4f6e-9a61-fdde" name="T-55AM2" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">14&quot; / 35cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">20&quot; / 50cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">24&quot; / 60cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">14</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">9</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">2</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">4+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ee71-cee9-9c83-d784" name="T-72M" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">24&quot; / 60cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">28&quot; / 70cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">15</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">8</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">2</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">4+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0fb8-0db9-cc75-e884" name="T-72M (HQ)" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">24&quot; / 60cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">28&quot; / 70cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">15</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">8</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">2</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">3+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">2+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">3+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="583e-9df2-8e29-4060" name="Mot. Schützen (HQ)" hidden="false" typeId="095d-7a5e-b507-44e4" typeName="Infantry Team">
+      <characteristics>
+        <characteristic name="Tactical move" typeId="e0ee-5804-d1a7-ffb3">8&quot; / 20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="ccbc-9147-7cef-acca">8&quot; / 20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="ba8c-85b8-4860-cd28">12&quot; / 30cm</characteristic>
+        <characteristic name="Road Dash" typeId="ad4b-3a11-05ef-daf4">12&quot; / 30cm</characteristic>
+        <characteristic name="Cross" typeId="93df-8d45-e422-9163">AUTO</characteristic>
+        <characteristic name="Is Hit On" typeId="b0ba-ff6a-b454-a926">3+</characteristic>
+        <characteristic name="Infantry Save" typeId="7ad2-ac9e-02fd-af45">3+</characteristic>
+        <characteristic name="Courage" typeId="3ea8-3e5a-9400-878e">3+</characteristic>
+        <characteristic name="Morale" typeId="68ce-356d-7a68-0eaf">2+</characteristic>
+        <characteristic name="Rally" typeId="2a3a-aed9-48b2-234a">3+</characteristic>
+        <characteristic name="Skill" typeId="eb99-12e9-c164-6fd6">3+</characteristic>
+        <characteristic name="Assault" typeId="060b-f9d6-0748-a496">5+</characteristic>
+        <characteristic name="Counter Attack" typeId="57d9-d0c4-dd83-6019">3+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6eb4-3db7-eb0e-64c7" name="Mot. Schützen" hidden="false" typeId="095d-7a5e-b507-44e4" typeName="Infantry Team">
+      <characteristics>
+        <characteristic name="Tactical move" typeId="e0ee-5804-d1a7-ffb3">8&quot; / 20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="ccbc-9147-7cef-acca">8&quot; / 20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="ba8c-85b8-4860-cd28">12&quot; / 30cm</characteristic>
+        <characteristic name="Road Dash" typeId="ad4b-3a11-05ef-daf4">12&quot; / 30cm</characteristic>
+        <characteristic name="Cross" typeId="93df-8d45-e422-9163">AUTO</characteristic>
+        <characteristic name="Is Hit On" typeId="b0ba-ff6a-b454-a926">3+</characteristic>
+        <characteristic name="Infantry Save" typeId="7ad2-ac9e-02fd-af45">3+</characteristic>
+        <characteristic name="Courage" typeId="3ea8-3e5a-9400-878e">4+</characteristic>
+        <characteristic name="Morale" typeId="68ce-356d-7a68-0eaf">3+</characteristic>
+        <characteristic name="Rally" typeId="2a3a-aed9-48b2-234a">4+</characteristic>
+        <characteristic name="Skill" typeId="eb99-12e9-c164-6fd6">4+</characteristic>
+        <characteristic name="Assault" typeId="060b-f9d6-0748-a496">5+</characteristic>
+        <characteristic name="Counter Attack" typeId="57d9-d0c4-dd83-6019">4+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4c8d-2653-5f4d-34ea" name="BMP-1 Transport" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">28&quot; / 70cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">32&quot; / 80cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">2</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">2</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">4+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4482-355f-472f-9540" name="BMP-2 Transport" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">24&quot; / 70cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">32&quot; / 80cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">2</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">2</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">5+</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">4+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b243-4696-d882-6872" name="BRDM-2" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">10&quot; / 25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">18&quot; / 40cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">44&quot; / 110cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">0</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">0</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cfcf-4d25-19ac-1443" name="BTR-60" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">10&quot; / 25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">16&quot; / 40cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">36&quot; / 90cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">0</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">0</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6fb1-ea8f-3630-b424" name="ZSU-23-4" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">14&quot; / 35cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">20&quot; / 50cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">24&quot; / 60cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">1</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9993-f4ea-0446-cca8" name="SA-13 Gopher" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">24&quot; / 60cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">28&quot; / 70cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">1</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">-</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="98a2-42b1-a443-8d8c" name="SA-9 Gaskin" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">10&quot; / 25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">18&quot; / 45cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">44&quot; / 110cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">0</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">0</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">-</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1f92-306f-f680-e17b" name="2S1 Carnation" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">24&quot; / 60cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">28&quot; / 70cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">2</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">1</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a397-9a75-58c5-11e9" name="BM-21" page="" hidden="false" typeId="1d0d-99f1-d80c-2026" typeName="Unarmored Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical Move" typeId="c12d-44b4-4826-9d0e">8&quot; / 20cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="5321-8ef2-2e31-96f7">8&quot; / 20cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="3e82-3246-6cf8-5f46">14&quot; / 35cm</characteristic>
+        <characteristic name="Road Dash" typeId="8254-878c-40b4-861c">36&quot; / 90cm</characteristic>
+        <characteristic name="Cross" typeId="18fa-7699-146f-6363">4+</characteristic>
+        <characteristic name="Is Hit On" typeId="9a7e-de6c-8c03-e998">3+</characteristic>
+        <characteristic name="Tank Save" typeId="9baa-1042-991e-640d">5+</characteristic>
+        <characteristic name="Courage" typeId="6e4b-43ef-87a8-252f">4+</characteristic>
+        <characteristic name="Morale" typeId="2b91-eafe-3aeb-c70b">3+</characteristic>
+        <characteristic name="Rally" typeId="2373-177f-ce29-78cb">4+</characteristic>
+        <characteristic name="Skill" typeId="1933-fc7d-e801-99ab">4+</characteristic>
+        <characteristic name="Assault" typeId="f004-e5d8-0da9-3d21">-</characteristic>
+        <characteristic name="Counterattack" typeId="498a-fd31-607a-feec">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d580-a060-f63a-a583" name="BMP-1 OP" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">16&quot; / 40cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">28&quot; / 70cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">32&quot; / 80cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">3+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">2</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">2</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">1</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">5+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="390f-b9b2-8601-9fb5" name="Spandrel" page="" hidden="false" typeId="e086-dcd6-1518-dc44" typeName="Tank Unit">
+      <characteristics>
+        <characteristic name="Tactical" typeId="0f95-1160-8137-2e70">10&quot; / 25cm</characteristic>
+        <characteristic name="Terrain Dash" typeId="f9c7-641e-a00f-0552">10&quot; / 25cm</characteristic>
+        <characteristic name="Cross Country Dash" typeId="8fd7-dfd5-de5e-e574">18&quot; / 45cm</characteristic>
+        <characteristic name="Road Dash" typeId="f778-f445-c19b-30d4">44&quot; / 110cm</characteristic>
+        <characteristic name="Cross" typeId="ae80-d6b0-cb1b-4c9c">4+</characteristic>
+        <characteristic name="Front" typeId="ca8b-c8f9-96f3-a913">1</characteristic>
+        <characteristic name="Side" typeId="a40f-72f4-3d35-ec93">0</characteristic>
+        <characteristic name="Top" typeId="f293-d7ab-abe0-c981">0</characteristic>
+        <characteristic name="Is Hit on" typeId="1a01-5cd5-d0d0-91c0">3+</characteristic>
+        <characteristic name="Courage" typeId="12e0-c8cc-7fb1-25b5">4+</characteristic>
+        <characteristic name="Morale" typeId="fb3f-6bb0-8c2b-d44a">3+</characteristic>
+        <characteristic name="Remount" typeId="39b2-e446-443a-ccaf">4+</characteristic>
+        <characteristic name="Skill" typeId="2347-c398-3cb7-2f91">4+</characteristic>
+        <characteristic name="Assault" typeId="071d-fb0c-dc9f-c97f">6</characteristic>
+        <characteristic name="Counterattack" typeId="552a-1058-00df-a425">6</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="aa77-fae6-d3fb-cb8d" name="MI-24 Hind" page="" hidden="false" typeId="cb62-cf79-c5be-c00b" typeName="Aircraft">
+      <characteristics>
+        <characteristic name="Is hit on" typeId="a94f-1214-dc73-0af0">3+</characteristic>
+        <characteristic name="Aircraft Save" typeId="cf80-c66b-9018-b7bc">4+</characteristic>
+        <characteristic name="Courage" typeId="c68f-dba5-3af1-dcfc">4+</characteristic>
+        <characteristic name="Morale" typeId="3af5-6c3e-3f0d-e308">3+</characteristic>
+        <characteristic name="Skill" typeId="d287-43b1-d61a-f837">4+</characteristic>
+        <characteristic name="Movement" typeId="0683-6f3b-3779-ddb2">UNLIMITED</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f61c-c5d3-c7b9-1f14" name="SU-25" page="" hidden="false" typeId="cb62-cf79-c5be-c00b" typeName="Aircraft">
+      <characteristics>
+        <characteristic name="Is hit on" typeId="a94f-1214-dc73-0af0">3+</characteristic>
+        <characteristic name="Aircraft Save" typeId="cf80-c66b-9018-b7bc">4+</characteristic>
+        <characteristic name="Courage" typeId="c68f-dba5-3af1-dcfc">4+</characteristic>
+        <characteristic name="Morale" typeId="3af5-6c3e-3f0d-e308">3+</characteristic>
+        <characteristic name="Skill" typeId="d287-43b1-d61a-f837">5+</characteristic>
+        <characteristic name="Movement" typeId="0683-6f3b-3779-ddb2">UNLIMITED</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1a40-d29d-d839-e5a2" name="100mm D10-T Gun" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">32&quot; / 80cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">17</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">2+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Laser Rangefinder, Slow Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5ebe-a76b-55c2-77b3" name="12.7mm AA MG" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">2</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">4</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93"/>
+      </characteristics>
+    </profile>
+    <profile id="48b3-b6b2-a416-c26b" name="7.62mm MG" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">2</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93"/>
+      </characteristics>
+    </profile>
+    <profile id="a510-dc46-6f16-2fe1" name="125mm 2A46 Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">32&quot; / 80cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">21</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">2+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Brutal, Laser Rangefinder, Advanced Stabiliser</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c1f6-5b26-6ffc-d80d" name="MPi KM Assault Rifle" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">3</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">1</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Pinned ROF 1</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3185-bebc-7338-7904" name="RPG-18 Anti-Tank " page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">14</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">HEAT, Slow-Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8dc7-ad22-bb6d-083d" name="RPG-7 Anti-Tank" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">12&quot; / 30cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">17</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">4+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Assault 6, HEAT, Slow-Firing</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="12f4-4268-76df-be1f" name="PKM LMG" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">7</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">4</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">2</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Assault 6, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="893e-a551-af40-221b" name="AGS-17 Grenade Launcher" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">9</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">3</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">3</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Assault 6, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7a00-2fce-ed14-0124" name="SA-14 Gremlin AA Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">48&quot; / 120cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">-</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Assault 6, Guided AA, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c4c9-b91c-8588-d5a7" name="73mm 2A28 Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">12</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a7ea-c688-4b20-20c9" name="AT-3 Sagger Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm - 44&quot; / 110cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">19</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Guided, HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f0a3-de9c-ffca-d337" name="7.62mm MG (BMP)" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">16&quot; / 40cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">2</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93"/>
+      </characteristics>
+    </profile>
+    <profile id="3fc0-6ccd-4647-3fd6" name="30mm 2A42 Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">2</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">10</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Anti-Helicopter, Stabiliser</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d4e5-9e8a-f6ee-76ed" name="AT-5 Spandrel Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm - 48&quot; / 120cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">21</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Guided, HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c17d-8c48-4969-99f5" name="14.5mm MG" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">2</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">5</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93"/>
+      </characteristics>
+    </profile>
+    <profile id="68d1-0a67-2224-f17c" name="AT-4 Spigot Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm - 40&quot; / 100cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">3</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">19</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Assault 6, Guided, HEAT, Heavy Weapon</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e489-34ba-f5e5-6793" name="23mm 2A7 AA Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">6</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">4</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">6</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Dedicated AA, Radar</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ec03-e222-3a10-c34a" name="SA-13 Gopher AA Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">56&quot; / 140cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">2</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">-</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">4+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Guided AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="13ff-86c4-a928-a02a" name="SA-9 Gaskin AA Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">48&quot; / 120cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">2</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">-</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">-</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Guided AA</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f2cb-e079-c31a-a84a" name="122mm 2A31 Howitzer" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">88&quot; / 220cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">ARTILLERY</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">ARTILLERY</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">4</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Smoke Bombardment</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ee59-fd4e-b46f-5c6e" name="122mm 2A31 Howitzer (Direct Fire)" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">24&quot; / 60cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">1</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">21</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">2+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Brutal, HEAT, Slow Firing, Smoke</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2d0f-8474-2038-83ff" name="BM-21 Rocket Launcher" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">96&quot; / 240cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">SALVO</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">SALVO</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">3</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">4+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Smoke Bombardment</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7a7c-9236-63aa-cad8" name="AT-6 Spiral Missile (Air Launched)" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm - 20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">-</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">23</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">3+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Guided, HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8e28-3cd6-a0db-b510" name="12.7mm YAK-B Gatling Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">-</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">3</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">5</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Anti-Helicopter</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5741-ed1d-d5bf-c52d" name="57mm UB-32 Rocket Launcher" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">20&quot; / 50cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">SALVO</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">SALVO</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">3</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">6</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">One Shot</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0393-f07c-35c6-d867" name="KH-25 Air-Ground Missile" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm - 28&quot; / 70cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">-</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">1</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">27</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">2+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Brutal, Guided, HEAT</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e5ed-0583-f5a3-7a06" name="30mm GSh-30-2 Gun" page="" hidden="false" typeId="c31a-db70-952b-43ec" typeName="Weapons">
+      <characteristics>
+        <characteristic name="Range" typeId="236c-2ce4-666b-bfe5">8&quot; / 20cm</characteristic>
+        <characteristic name="ROF Halted" typeId="7a61-c54f-97c9-9ecd">-</characteristic>
+        <characteristic name="ROF Moving" typeId="9696-6fb3-ca9f-9769">3</characteristic>
+        <characteristic name="Anti-tank" typeId="b1ef-a4e9-0f52-3c13">7</characteristic>
+        <characteristic name="Firepower" typeId="798b-75af-3f7d-0b25">5+</characteristic>
+        <characteristic name="Notes" typeId="e028-835f-f0cf-cb93">Anti-Helicopter</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+  <sharedInfoGroups>
+    <infoGroup id="2ff0-5a96-bf0a-344b" name="T-55AM2 HQ" hidden="false">
+      <infoLinks>
+        <infoLink id="9e45-204b-865b-708e" name="T-55AM2 (HQ)" hidden="false" targetId="c68b-38e7-ce4a-d572" type="profile"/>
+        <infoLink id="e5e1-dc45-d6a1-8f0d" name="Bazooka Skirts" hidden="false" targetId="2cb5-d057-feb4-dd26" type="rule"/>
+        <infoLink id="b412-91b4-5a78-ad5c" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="3d3c-2b6e-97ac-be92" name="100mm D10-T Gun" hidden="false" targetId="4a75-3205-a257-e0bc" type="infoGroup"/>
+        <infoLink id="15ac-9938-ad97-e71b" name="12.7mm AA MG" hidden="false" targetId="deaa-3ba0-b92e-6587" type="infoGroup"/>
+        <infoLink id="70c1-391c-e71c-9f5a" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="4a75-3205-a257-e0bc" name="100mm D10-T Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="d775-97c9-da34-1ad5" name="100mm D10-T Gun" hidden="false" targetId="1a40-d29d-d839-e5a2" type="profile"/>
+        <infoLink id="ce68-c8f0-334b-6104" name="Laser Rangefinder" hidden="false" targetId="ab4f-6615-cc38-6418" type="rule"/>
+        <infoLink id="f7b2-e870-20f1-b105" name="Slow Firing" hidden="false" targetId="2037-79f0-8461-6a15" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="deaa-3ba0-b92e-6587" name="12.7mm AA MG" hidden="false">
+      <infoLinks>
+        <infoLink id="dcfc-e71b-d1d2-bd9f" name="AA MG" hidden="false" targetId="60ba-123c-4f2a-1604" type="rule"/>
+        <infoLink id="b426-576a-afac-fa4b" name="12.7mm AA MG" hidden="false" targetId="5ebe-a76b-55c2-77b3" type="profile"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="0615-7b78-d9be-9aa8" name="T-55AM2" hidden="false">
+      <infoLinks>
+        <infoLink id="dea7-fb37-be92-d878" name="T-55AM2" hidden="false" targetId="8c7f-4f6e-9a61-fdde" type="profile"/>
+        <infoLink id="c0a7-a798-792b-a599" name="Bazooka Skirts" hidden="false" targetId="2cb5-d057-feb4-dd26" type="rule"/>
+        <infoLink id="a36e-72a6-801b-79fe" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="d64c-f24d-5cda-d56a" name="100mm D10-T Gun" hidden="false" targetId="4a75-3205-a257-e0bc" type="infoGroup"/>
+        <infoLink id="2d95-8c08-9e05-e87b" name="12.7mm AA MG" hidden="false" targetId="deaa-3ba0-b92e-6587" type="infoGroup"/>
+        <infoLink id="e85e-f084-7cd5-985c" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="676b-0807-3ec4-e6e8" name="T-72M HQ" hidden="false">
+      <infoLinks>
+        <infoLink id="3630-7401-13a6-a32e" name="Bazooka Skirts" hidden="false" targetId="2cb5-d057-feb4-dd26" type="rule"/>
+        <infoLink id="c079-53fb-f87c-2790" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="7dc1-8ece-f4f6-bf21" name="12.7mm AA MG" hidden="false" targetId="deaa-3ba0-b92e-6587" type="infoGroup"/>
+        <infoLink id="75a8-e268-e695-83f0" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+        <infoLink id="08dd-8f9d-173a-f208" name="125mm 2A46 Gun" hidden="false" targetId="1298-f70f-555d-57b9" type="infoGroup"/>
+        <infoLink id="6d60-5817-850f-8f8c" name="T-72M" hidden="false" targetId="ee71-cee9-9c83-d784" type="profile"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="1298-f70f-555d-57b9" name="125mm 2A46 Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="ffb3-9508-74f5-3825" name="125mm 2A46 Gun" hidden="false" targetId="a510-dc46-6f16-2fe1" type="profile"/>
+        <infoLink id="c0e6-772b-3e92-1bf1" name="Brutal" hidden="false" targetId="2102-fd36-69d4-0b93" type="rule"/>
+        <infoLink id="36b8-8074-55ab-bec0" name="Laser Rangefinder" hidden="false" targetId="ab4f-6615-cc38-6418" type="rule"/>
+        <infoLink id="ee5b-f05b-5887-0acf" name="Stabliser" hidden="false" targetId="d3fb-834f-d6a6-3a25" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="996e-53a5-bace-e802" name="T-72M" hidden="false">
+      <infoLinks>
+        <infoLink id="a289-02e9-092a-e5bf" name="Bazooka Skirts" hidden="false" targetId="2cb5-d057-feb4-dd26" type="rule"/>
+        <infoLink id="3ce4-9ad4-7afa-96d6" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="ef8e-81a3-a40f-da4b" name="12.7mm AA MG" hidden="false" targetId="deaa-3ba0-b92e-6587" type="infoGroup"/>
+        <infoLink id="0db2-3fa9-acda-af52" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+        <infoLink id="d20d-4ffd-018a-21e9" name="125mm 2A46 Gun" hidden="false" targetId="1298-f70f-555d-57b9" type="infoGroup"/>
+        <infoLink id="c4d6-ff52-46b4-43b3" name="T-72M (HQ)" hidden="false" targetId="0fb8-0db9-cc75-e884" type="profile"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="c7de-9621-6a57-ea96" name="MPi KM Assault Rifle" hidden="false">
+      <infoLinks>
+        <infoLink id="1883-0cf9-206f-c0f3" name="MPi KM Assault Rifle" hidden="false" targetId="c1f6-5b26-6ffc-d80d" type="profile"/>
+        <infoLink id="d5ce-489a-7279-014f" name="Pinned ROF 1" hidden="false" targetId="1567-d8ea-bc21-5566" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="2261-85c9-7379-793e" name="MPi KM team" hidden="false">
+      <infoLinks>
+        <infoLink id="80fe-04b9-aacb-e1cd" name="Mot. Schützen (HQ)" hidden="false" targetId="583e-9df2-8e29-4060" type="profile"/>
+        <infoLink id="3637-df88-7900-7e4e" name="MPi KM Assault Rifle" hidden="false" targetId="c7de-9621-6a57-ea96" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="2107-ea22-4683-d2d3" name="MPi KM team with RPG-18 Anti-Tank" hidden="false">
+      <infoLinks>
+        <infoLink id="de08-8ee0-c886-78c4" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="ffe3-029e-3231-0a2c" name="MPi KM Assault Rifle" hidden="false" targetId="c7de-9621-6a57-ea96" type="infoGroup"/>
+        <infoLink id="8749-49f8-191c-0e89" name="RPG-18 Anti-Tank" hidden="false" targetId="bd07-a43e-1998-4607" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="bd07-a43e-1998-4607" name="RPG-18 Anti-Tank" hidden="false">
+      <infoLinks>
+        <infoLink id="259f-59b3-aaf9-acbc" name="RPG-18 Anti-Tank " hidden="false" targetId="3185-bebc-7338-7904" type="profile"/>
+        <infoLink id="c902-9ad1-de8a-21bb" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+        <infoLink id="7bfa-887d-aa50-c8d5" name="Slow Firing" hidden="false" targetId="2037-79f0-8461-6a15" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="d4f9-b76f-4f4e-836d" name="RPG-7 Anti-Tank" hidden="false">
+      <infoLinks>
+        <infoLink id="af02-4c35-4729-ddda" name="RPG-7 Anti-Tank" hidden="false" targetId="8dc7-ad22-bb6d-083d" type="profile"/>
+        <infoLink id="2a49-0f2b-787c-7b53" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+        <infoLink id="c638-9ad2-18c3-168d" name="Slow Firing" hidden="false" targetId="2037-79f0-8461-6a15" type="rule"/>
+        <infoLink id="bb1d-7980-1017-51a1" name="Assault #" hidden="false" targetId="b814-659f-46f8-b83a" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="3d64-5d57-450a-218c" name="PKM LMG" hidden="false">
+      <infoLinks>
+        <infoLink id="f884-b537-50f1-24cd" name="PKM LMG" hidden="false" targetId="12f4-4268-76df-be1f" type="profile"/>
+        <infoLink id="75c5-e3cb-e0ce-99e3" name="Heavy Weapon" hidden="false" targetId="d661-451e-b329-b452" type="rule"/>
+        <infoLink id="ccac-1d5a-084c-d705" name="Assault #" hidden="false" targetId="b814-659f-46f8-b83a" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="2a6a-1725-a551-e1f3" name="RPG-7 Anti-Tank Team" hidden="false">
+      <infoLinks>
+        <infoLink id="664c-5327-cf6b-aa20" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="a0de-772b-61c9-b2b7" name="RPG-7 Anti-Tank" hidden="false" targetId="d4f9-b76f-4f4e-836d" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="7155-8f80-7d87-3e6e" name="PKM LMG Team" hidden="false">
+      <infoLinks>
+        <infoLink id="56ba-3853-19de-427a" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="e5fc-b18a-2196-bc4e" name="PKM LMG" hidden="false" targetId="3d64-5d57-450a-218c" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="f202-af51-5bdd-b993" name="AGS-17 Grenade Launcher" hidden="false">
+      <infoLinks>
+        <infoLink id="ca52-6cb8-e308-89eb" name="AGS-17 Grenade Launcher" hidden="false" targetId="893e-a551-af40-221b" type="profile"/>
+        <infoLink id="dddd-8612-04eb-6f40" name="Assault #" hidden="false" targetId="b814-659f-46f8-b83a" type="rule"/>
+        <infoLink id="7406-a0d4-462c-06c9" name="Heavy Weapon" hidden="false" targetId="d661-451e-b329-b452" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="b85f-ff31-1d9e-0739" name="SA-14 Gremlin AA Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="be86-3731-42de-5a0c" name="SA-14 Gremlin AA Missile" hidden="false" targetId="7a00-2fce-ed14-0124" type="profile"/>
+        <infoLink id="c0e3-bb05-1211-6f7d" name="Assault #" hidden="false" targetId="b814-659f-46f8-b83a" type="rule"/>
+        <infoLink id="6588-0e73-2b31-9ba4" name="Guided AA" hidden="false" targetId="8fe0-6df6-1e26-7ec2" type="rule"/>
+        <infoLink id="eeb5-af50-b97d-27e8" name="Heavy Weapon" hidden="false" targetId="d661-451e-b329-b452" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="7f06-4e86-450a-eec5" name="SA-14 Gremlin AA Missile Team" hidden="false">
+      <infoLinks>
+        <infoLink id="88d2-0900-8d92-303c" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="956a-28eb-cdcf-171c" name="SA-14 Gremlin AA Missile" hidden="false" targetId="b85f-ff31-1d9e-0739" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="8fc6-6599-6fdc-b461" name="73mm 2A28 Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="b46b-644a-11b1-7258" name="73mm 2A28 Gun" hidden="false" targetId="c4c9-b91c-8588-d5a7" type="profile"/>
+        <infoLink id="6a93-c01a-a120-cd61" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="30c3-dcce-044b-7580" name="AT-3 Sagger Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="d98c-6df7-e077-625f" name="AT-3 Sagger Missile" hidden="false" targetId="a7ea-c688-4b20-20c9" type="profile"/>
+        <infoLink id="198d-4780-f385-ac1c" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+        <infoLink id="b951-ed66-a4b9-83c4" name="Guided" hidden="false" targetId="5571-a7f9-133c-dd58" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="a47c-ccb6-9cd3-1a95" name="BMP-1 Transport" hidden="false">
+      <infoLinks>
+        <infoLink id="1d92-82c6-6650-75c1" name="BMP-1 Transport" hidden="false" targetId="4c8d-2653-5f4d-34ea" type="profile"/>
+        <infoLink id="fe11-0e8d-c85c-7af7" name="73mm 2A28 Gun" hidden="false" targetId="8fc6-6599-6fdc-b461" type="infoGroup"/>
+        <infoLink id="f765-3bb5-5cd9-8a98" name="AT-3 Sagger Missile" hidden="false" targetId="30c3-dcce-044b-7580" type="infoGroup"/>
+        <infoLink id="6f32-cb26-db59-bd8d" name="7.62mm MG (BMP)" hidden="false" targetId="f0a3-de9c-ffca-d337" type="profile"/>
+        <infoLink id="f0c0-9af1-a5f0-f391" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="61e2-2330-ae84-6b79" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="e833-f85a-83f5-e6fc" name="Passengers 2" hidden="false" targetId="a5b9-484d-9c48-b035" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="91e6-9a5c-7ae7-f87c" name="30mm 2A42 Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="2717-5d34-5a93-0285" name="30mm 2A42 Gun" hidden="false" targetId="3fc0-6ccd-4647-3fd6" type="profile"/>
+        <infoLink id="3c8a-f63d-ffd1-559c" name="Anti-Helicopter" hidden="false" targetId="8e4a-59b8-2d58-8f33" type="rule"/>
+        <infoLink id="dc8a-6b4e-09a3-7f82" name="Stabliser" hidden="false" targetId="d3fb-834f-d6a6-3a25" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="4bbf-381b-4aa7-574d" name="AT-5 Spandrel Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="1eb4-f2bf-9aa8-99fd" name="AT-5 Spandrel Missile" hidden="false" targetId="d4e5-9e8a-f6ee-76ed" type="profile"/>
+        <infoLink id="51ad-f6c5-14cf-6b62" name="Guided" hidden="false" targetId="5571-a7f9-133c-dd58" type="rule"/>
+        <infoLink id="3afb-febb-d187-ddd8" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="1230-22e4-dde4-c526" name="BMP-2 Transport" hidden="false">
+      <infoLinks>
+        <infoLink id="1295-c931-9504-5d81" name="BMP-2 Transport" hidden="false" targetId="4482-355f-472f-9540" type="profile"/>
+        <infoLink id="3e6e-6013-1dbc-818d" name="7.62mm MG (BMP)" hidden="false" targetId="f0a3-de9c-ffca-d337" type="profile"/>
+        <infoLink id="17e4-b6ab-a72b-7787" name="AT-5 Spandrel Missile" hidden="false" targetId="4bbf-381b-4aa7-574d" type="infoGroup"/>
+        <infoLink id="75a0-e1d2-c4d6-9883" name="30mm 2A42 Gun" hidden="false" targetId="91e6-9a5c-7ae7-f87c" type="infoGroup"/>
+        <infoLink id="0929-1834-eb80-e39c" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="6f64-7804-e0c9-d7a6" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="93ba-885e-36e1-3c42" name="Passengers 2" hidden="false" targetId="a5b9-484d-9c48-b035" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="6aa0-ad60-8739-21a4" name="BRDM-2" hidden="false">
+      <infoLinks>
+        <infoLink id="dab9-19cd-7a8b-c887" name="BRDM-2" hidden="false" targetId="b243-4696-d882-6872" type="profile"/>
+        <infoLink id="ecc3-53c6-df5e-baea" name="14.5mm MG" hidden="false" targetId="c17d-8c48-4969-99f5" type="profile"/>
+        <infoLink id="0aad-34df-038e-3d30" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+        <infoLink id="507d-9907-5193-0e1c" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="8710-505d-ea1a-4a32" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="5425-b426-6e86-cc1b" name="Spearhead" hidden="false" targetId="e9cf-a511-2a6a-6507" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="0547-667e-3bf4-998d" name="AT-4 Spigot Missile Team" hidden="false">
+      <infoLinks>
+        <infoLink id="fa1a-fbb0-2ff7-41ff" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="2dac-983d-4b37-f7a7" name="AT-4 Spigot Missile" hidden="false" targetId="74ec-eb68-ccef-f78e" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="74ec-eb68-ccef-f78e" name="AT-4 Spigot Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="71fd-5dd2-e147-e0d4" name="AT-4 Spigot Missile" hidden="false" targetId="68d1-0a67-2224-f17c" type="profile"/>
+        <infoLink id="53c0-0d31-6b77-1862" name="Assault #" hidden="false" targetId="b814-659f-46f8-b83a" type="rule"/>
+        <infoLink id="8ffa-9334-0f44-2bfc" name="Guided" hidden="false" targetId="5571-a7f9-133c-dd58" type="rule"/>
+        <infoLink id="13a3-3054-141c-c04f" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+        <infoLink id="2035-1741-52b6-91e9" name="Heavy Weapon" hidden="false" targetId="d661-451e-b329-b452" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="6585-d177-8b83-1398" name="23mm 2A7 AA Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="df27-7b2e-2571-9510" name="23mm 2A7 AA Gun" hidden="false" targetId="e489-34ba-f5e5-6793" type="profile"/>
+        <infoLink id="3de5-38e2-d21d-af88" name="Dedicated AA" hidden="false" targetId="514b-1009-1db9-e89a" type="rule"/>
+        <infoLink id="d925-b17f-ba20-76e9" name="Radar (ZSU-23-4)" hidden="false" targetId="e32c-57a4-c7ac-d368" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="8faf-afd1-3825-b756" name="ZSU-23-4 Shilka" hidden="false">
+      <infoLinks>
+        <infoLink id="b38f-1bcf-afb4-38e1" name="ZSU-23-4" hidden="false" targetId="6fb1-ea8f-3630-b424" type="profile"/>
+        <infoLink id="7f2a-8e19-16c7-be8b" name="23mm 2A7 AA Gun" hidden="false" targetId="6585-d177-8b83-1398" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="adfc-f353-77e7-a04f" name="SA-13 Gopher AA Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="9190-24f2-bfb9-1f50" name="SA-13 Gopher AA Missile" hidden="false" targetId="ec03-e222-3a10-c34a" type="profile"/>
+        <infoLink id="777a-91f9-3c0b-75e5" name="Guided AA" hidden="false" targetId="8fe0-6df6-1e26-7ec2" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="5dbd-dd48-6390-3b32" name="SA-13 Gopher" hidden="false">
+      <infoLinks>
+        <infoLink id="8832-c989-2aa0-4b41" name="SA-13 Gopher" hidden="false" targetId="9993-f4ea-0446-cca8" type="profile"/>
+        <infoLink id="f4be-e8da-a6e9-ee91" name="SA-13 Gopher AA Missile" hidden="false" targetId="adfc-f353-77e7-a04f" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="6bdc-2da9-28e2-cb10" name="SA-9 Gaskin AA Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="998a-d562-20c8-53b0" name="SA-9 Gaskin AA Missile" hidden="false" targetId="13ff-86c4-a928-a02a" type="profile"/>
+        <infoLink id="d6e3-04ed-2141-731b" name="Guided AA" hidden="false" targetId="8fe0-6df6-1e26-7ec2" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="b7d8-ed39-ff7c-fc0f" name="SA-9 Gaskin" hidden="false">
+      <infoLinks>
+        <infoLink id="2c9a-133d-9308-8085" name="SA-9 Gaskin" hidden="false" targetId="98a2-42b1-a443-8d8c" type="profile"/>
+        <infoLink id="07ec-4f64-0632-f62b" name="SA-9 Gaskin AA Missile" hidden="false" targetId="6bdc-2da9-28e2-cb10" type="infoGroup"/>
+        <infoLink id="0c7a-b443-4d16-8d61" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="e1fc-c260-89f2-aba4" name="122mm 2A31 Howitzer" hidden="false">
+      <infoLinks>
+        <infoLink id="d252-6755-8fef-3723" name="122mm 2A31 Howitzer" hidden="false" targetId="f2cb-e079-c31a-a84a" type="profile"/>
+        <infoLink id="8bf5-0704-7e81-a383" name="Smoke Bombardment" hidden="false" targetId="9897-8e4d-613a-55cb" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="1502-afc0-b1de-322a" name="122mm 2A31 Howitzer (Direct Fire)" hidden="false">
+      <infoLinks>
+        <infoLink id="3185-f97f-7028-dd9b" name="122mm 2A31 Howitzer (Direct Fire)" hidden="false" targetId="ee59-fd4e-b46f-5c6e" type="profile"/>
+        <infoLink id="2445-d396-fd33-7c29" name="Brutal" hidden="false" targetId="2102-fd36-69d4-0b93" type="rule"/>
+        <infoLink id="43f3-618d-922d-6b99" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+        <infoLink id="a723-a680-2238-a0c0" name="Slow Firing" hidden="false" targetId="2037-79f0-8461-6a15" type="rule"/>
+        <infoLink id="7e14-0b40-3d91-942c" name="Smoke" hidden="false" targetId="f3d4-cf1f-bfdd-e76c" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="623a-16c8-281a-144a" name="BM-21" hidden="false">
+      <infoLinks>
+        <infoLink id="6b16-1a11-91ba-417a" name="BM-21" hidden="false" targetId="a397-9a75-58c5-11e9" type="profile"/>
+        <infoLink id="023d-fcf5-fdec-fe9b" name="BM-21 Rocket Launcher" hidden="false" targetId="2d0f-8474-2038-83ff" type="profile"/>
+        <infoLink id="9fcb-b12e-2fb5-b362" name="Smoke Bombardment" hidden="false" targetId="9897-8e4d-613a-55cb" type="rule"/>
+        <infoLink id="017d-3f3b-36ae-039d" name="Unarmoured" hidden="false" targetId="5dac-a918-145f-931e" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="5abf-974f-8cd3-e144" name="BMP-1 Observation Post" hidden="false">
+      <infoLinks>
+        <infoLink id="0864-c241-11fb-4d91" name="BMP-1 OP" hidden="false" targetId="d580-a060-f63a-a583" type="profile"/>
+        <infoLink id="b0d3-34b5-4cf3-0920" name="Independent" hidden="false" targetId="60c8-03f2-c543-a6ea" type="rule"/>
+        <infoLink id="6e30-9cdf-da1e-12fa" name="7.62mm MG (BMP)" hidden="false" targetId="f0a3-de9c-ffca-d337" type="profile"/>
+        <infoLink id="c510-ca0e-2fc0-043b" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="2c59-48db-2f8e-506f" name="Scout" hidden="false" targetId="9df5-f39b-4148-24ca" type="rule"/>
+        <infoLink id="cbf0-0763-5fa9-1b9c" name="Observer" hidden="false" targetId="e41f-bf7a-3766-c44c" type="rule"/>
+        <infoLink id="ac5e-16ba-1132-74d3" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="c354-3a5a-5c68-4116" name="Spandrel" hidden="false">
+      <infoLinks>
+        <infoLink id="5503-ff32-4fdf-4cc3" name="Spandrel" hidden="false" targetId="390f-b9b2-8601-9fb5" type="profile"/>
+        <infoLink id="d9e9-235f-4e52-c3b4" name="AT-5 Spandrel Missile" hidden="false" targetId="4bbf-381b-4aa7-574d" type="infoGroup"/>
+        <infoLink id="a11d-08e0-a2ea-902a" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="79ab-2187-4acb-d0a9" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="d782-dd3d-c2d4-134b" name="AT-6 Spiral Missile (Air Launched)" hidden="false">
+      <infoLinks>
+        <infoLink id="cac6-cd39-f597-5433" name="AT-6 Spiral Missile (Air Launched)" hidden="false" targetId="7a7c-9236-63aa-cad8" type="profile"/>
+        <infoLink id="30c9-d3f4-c653-c2b9" name="Guided" hidden="false" targetId="5571-a7f9-133c-dd58" type="rule"/>
+        <infoLink id="4d14-49fb-f5e9-17fb" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="54d0-b024-7d50-4007" name="12.7mm YAK-B Gatling Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="d7e1-8fe9-e956-4ef2" name="12.7mm YAK-B Gatling Gun" hidden="false" targetId="8e28-3cd6-a0db-b510" type="profile"/>
+        <infoLink id="9f54-8727-ac95-2b30" name="Anti-Helicopter" hidden="false" targetId="8e4a-59b8-2d58-8f33" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="e8c8-adb1-da25-18b4" name="57mm UB-32 Rocket Launcher" hidden="false">
+      <infoLinks>
+        <infoLink id="87fc-ccdf-dc3b-e2ef" name="57mm UB-32 Rocket Launcher" hidden="false" targetId="5741-ed1d-d5bf-c52d" type="profile"/>
+        <infoLink id="abc8-8c1f-c197-e8df" name="One Shot" hidden="false" targetId="42d2-8e63-990e-68f9" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="dfa7-4dbb-e22d-cc9f" name="MI-24 Hind" hidden="false">
+      <infoLinks>
+        <infoLink id="8fe6-0c8f-4a18-28fd" name="MI-24 Hind" hidden="false" targetId="aa77-fae6-d3fb-cb8d" type="profile"/>
+        <infoLink id="51f0-f2dd-7133-024b" name="57mm UB-32 Rocket Launcher" hidden="false" targetId="e8c8-adb1-da25-18b4" type="infoGroup"/>
+        <infoLink id="8cfa-73d6-d880-dde6" name="12.7mm YAK-B Gatling Gun" hidden="false" targetId="54d0-b024-7d50-4007" type="infoGroup"/>
+        <infoLink id="bf17-8915-bc64-9c04" name="AT-6 Spiral Missile (Air Launched)" hidden="false" targetId="d782-dd3d-c2d4-134b" type="infoGroup"/>
+        <infoLink id="787b-f375-ded5-93b8" name="Helicopter" hidden="false" targetId="76be-ca09-2356-b61c" type="rule"/>
+        <infoLink id="8fd9-67b2-adfe-a7b5" name="Passengers 2" hidden="false" targetId="a5b9-484d-9c48-b035" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="e870-cb25-9e2e-55c5" name="SU-25 Frogfoot" hidden="false">
+      <infoLinks>
+        <infoLink id="19ed-c040-47f2-48f9" name="SU-25" hidden="false" targetId="f61c-c5d3-c7b9-1f14" type="profile"/>
+        <infoLink id="2cd2-ed13-c8a8-0223" name="57mm UB-32 Rocket Launcher" hidden="false" targetId="e8c8-adb1-da25-18b4" type="infoGroup"/>
+        <infoLink id="8914-94c4-83a9-68b7" name="KH-25 Air-Ground Missile" hidden="false" targetId="3026-d587-0544-cfdf" type="infoGroup"/>
+        <infoLink id="d902-4759-e793-dab8" name="30mm GSh-30-2 Gun" hidden="false" targetId="3eb4-389a-86df-acb2" type="infoGroup"/>
+        <infoLink id="8608-ce08-6dd8-d286" name="Strike Aircraft" hidden="false" targetId="c9ad-9317-fa93-e4f2" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="3026-d587-0544-cfdf" name="KH-25 Air-Ground Missile" hidden="false">
+      <infoLinks>
+        <infoLink id="01b8-b003-4a5b-9c15" name="KH-25 Air-Ground Missile" hidden="false" targetId="0393-f07c-35c6-d867" type="profile"/>
+        <infoLink id="8896-6552-dd38-a318" name="Brutal" hidden="false" targetId="2102-fd36-69d4-0b93" type="rule"/>
+        <infoLink id="208d-f687-4372-391f" name="Guided" hidden="false" targetId="5571-a7f9-133c-dd58" type="rule"/>
+        <infoLink id="639a-89b7-c067-aa55" name="HEAT" hidden="false" targetId="4ac0-f918-a4e1-d232" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="3eb4-389a-86df-acb2" name="30mm GSh-30-2 Gun" hidden="false">
+      <infoLinks>
+        <infoLink id="882e-9023-6f00-aed0" name="30mm GSh-30-2 Gun" hidden="false" targetId="e5ed-0583-f5a3-7a06" type="profile"/>
+        <infoLink id="6baa-cd46-bab5-debb" name="Anti-Helicopter" hidden="false" targetId="8e4a-59b8-2d58-8f33" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="8a5a-ae19-8ac9-f046" name="AGS-17 Grenade Launcher Team" hidden="false">
+      <infoLinks>
+        <infoLink id="8d67-b64c-bbaf-3fdc" name="Mot. Schützen" hidden="false" targetId="6eb4-3db7-eb0e-64c7" type="profile"/>
+        <infoLink id="457f-276e-92ed-e6df" name="AGS-17 Grenade Launcher" hidden="false" targetId="f202-af51-5bdd-b993" type="infoGroup"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="1201-c37d-e42f-fe07" name="BMP-1 Scout" hidden="false">
+      <infoLinks>
+        <infoLink id="36b1-b1a3-4e52-f20f" name="BMP-1 Transport" hidden="false" targetId="4c8d-2653-5f4d-34ea" type="profile"/>
+        <infoLink id="256b-4fc7-ad9f-a497" name="7.62mm MG (BMP)" hidden="false" targetId="f0a3-de9c-ffca-d337" type="profile"/>
+        <infoLink id="47b0-f6d5-b7ff-dd76" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="4eb8-b701-d686-a62d" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+        <infoLink id="edff-e957-d50d-174f" name="73mm 2A28 Gun" hidden="false" targetId="8fc6-6599-6fdc-b461" type="infoGroup"/>
+        <infoLink id="a72c-12ac-29ed-310b" name="AT-3 Sagger Missile" hidden="false" targetId="30c3-dcce-044b-7580" type="infoGroup"/>
+        <infoLink id="1b27-dc11-050c-5aeb" name="Spearhead" hidden="false" targetId="e9cf-a511-2a6a-6507" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="484d-16eb-e663-2d97" name="BTR-60 Transport" hidden="false">
+      <infoLinks>
+        <infoLink id="d9e0-abd5-c6ec-e5f1" name="BTR-60" hidden="false" targetId="cfcf-4d25-19ac-1443" type="profile"/>
+        <infoLink id="713a-eb84-ec99-5c67" name="14.5mm MG" hidden="false" targetId="c17d-8c48-4969-99f5" type="profile"/>
+        <infoLink id="b9ef-16e8-b9ab-b295" name="7.62mm MG" hidden="false" targetId="48b3-b6b2-a416-c26b" type="profile"/>
+        <infoLink id="3032-8e7d-4e3a-8b3c" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="6c90-9bbc-8d37-f090" name="Passengers 2" hidden="false" targetId="a5b9-484d-9c48-b035" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+    <infoGroup id="b439-7b1b-1cb8-4909" name="2S1 Carnation" hidden="false">
+      <infoLinks>
+        <infoLink id="99d1-afa2-4c1a-1a44" name="122mm 2A31 Howitzer" hidden="false" targetId="e1fc-c260-89f2-aba4" type="infoGroup"/>
+        <infoLink id="21e3-b99d-17f3-95a6" name="2S1 Carnation" hidden="false" targetId="1f92-306f-f680-e17b" type="profile"/>
+        <infoLink id="dabe-818f-7de2-0bce" name="122mm 2A31 Howitzer (Direct Fire)" hidden="false" targetId="1502-afc0-b1de-322a" type="infoGroup"/>
+        <infoLink id="8bbb-3f4c-474e-2c85" name="Amphibious" hidden="false" targetId="5807-4eac-7fae-eda0" type="rule"/>
+        <infoLink id="0cfe-bdb9-f034-6791" name="Infra-Red" hidden="false" targetId="e794-7147-1c60-5942" type="rule"/>
+      </infoLinks>
+    </infoGroup>
+  </sharedInfoGroups>
+</catalogue>


### PR DESCRIPTION
Added Catalogue "Volksarmee - East Germans in World War III.cat"

Red Thunder - Soviets in World War III.cat
Fix: AT-3 Sagger had no max Range
Fix: BMPs have a unique 7.62mm MG Profile.

Team Yankee WW3.gst
Typo: Assault Rule had typos